### PR TITLE
Adds support for the "optional" function

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": true
+}

--- a/src/useSchema.ts
+++ b/src/useSchema.ts
@@ -1,6 +1,10 @@
+import getNestedProperty from './utils/getNestedProperty'
+
 interface Schema {
-  [key: string]: ResolversGroup | Resolver | Schema
+  [key: string]: SchemaValue
 }
+
+type SchemaValue = ResolversGroup | Resolver | Schema
 
 type Pointer = string[]
 
@@ -41,33 +45,45 @@ function getErrorsBySchema(schema: Schema, data: Object, pointer: Pointer) {
     const currentPointer = pointer.concat(key)
 
     // Handle values that are expected by schema, but not defined in data.
-    if (typeof data === 'undefined' || data === null) {
+    if (data == null) {
       return errors.concat(createValidationError(currentPointer, data))
     }
 
     const value = data[key]
-    const resolver = schema[key]
+    const resolverPayload = schema[key]
+
+    // When a resolver function returns an Array,
+    // treat the first argument as a predicate that determines if validation is necessary.
+    // Threat the second argument as the resolver function.
+    const [predicate, resolver] = Array.isArray(resolverPayload)
+      ? resolverPayload
+      : [() => true, resolverPayload]
+    const shouldValidate = predicate(value, key, currentPointer, data, schema)
+
+    if (!shouldValidate) {
+      return errors
+    }
 
     if (typeof resolver === 'object') {
       return errors.concat(getErrorsBySchema(resolver, value, currentPointer))
     }
 
-    const resolverOutput = resolver(value, currentPointer)
+    const resolverVerdict = resolver(value, currentPointer)
 
     // If resolver returns an Object, treat it as named rules map.
-    if (typeof resolverOutput === 'object') {
-      const namedErrors = Object.keys(resolverOutput)
-        .filter((rule) => !resolverOutput[rule])
+    if (typeof resolverVerdict === 'object') {
+      const namedErrors = Object.keys(resolverVerdict)
+        // Note that named resolvers keep a boolean value,
+        // not the verdict function. Therefore, no calls.
+        .filter((rule) => !resolverVerdict[rule])
         .reduce((acc, rule) => {
-          return acc.concat(
-            createValidationError(currentPointer, value, rule),
-          )
+          return acc.concat(createValidationError(currentPointer, value, rule))
         }, [])
       return errors.concat(namedErrors)
     }
 
-    // Otherwise resolver is expected to return a boolean.
-    return resolverOutput
+    // Otherwise resolver is a function that returns a boolean verdict
+    return resolverVerdict
       ? errors
       : errors.concat(createValidationError(currentPointer, value))
   }, [])
@@ -86,6 +102,19 @@ function createValidationError(
     status,
     rule,
   }
+}
+
+/**
+ * High-order resolver that applies a given resolver function
+ * only when the associated property is present in the actual data.
+ */
+export const optional = (payload: SchemaValue) => {
+  return [
+    (value, key, pointer, data, schema) => {
+      return getNestedProperty(pointer, data) != null
+    },
+    payload,
+  ]
 }
 
 export default useSchema

--- a/src/utils/getNestedProperty.ts
+++ b/src/utils/getNestedProperty.ts
@@ -1,0 +1,18 @@
+export default function getNestedProperty<I, O = any>(
+  paths: string[],
+  obj: I,
+): O {
+  let value = obj as any
+  let index = 0
+
+  while (index < paths.length) {
+    if (value === null) {
+      return
+    }
+
+    value = value[paths[index]]
+    index += 1
+  }
+
+  return value
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compileOnSave": true,
   "compilerOptions": {
-    "lib": ["esnext", "dom"]
+    "esModuleInterop": true,
+    "lib": ["esnext", "dom"],
   }
 }


### PR DESCRIPTION
This pull request adds the functionality for weak validation of data properties.

## Example

```js
import { useSchema, optional } from 'reach-schema'

const { errors } = useSchema(
  {
    firstName: optional(value => value.length > 1)
  },
  {}
)
```

> This schema lists the `firstName` property as optional. It will be validated only when it's present in the actual data object.