### PR TITLE
Emits type definitions alongside the build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,5 +3,9 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "lib": ["esnext", "dom"],
-  }
+    "outDir": "types",
+    "declaration": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Changes:

- Configures TypeScript so it emits type definitions into the package's build to be consumable by other packages